### PR TITLE
Hide sensitive headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ It uses [timbre](https://github.com/ptaoussanis/timbre) as a logging library.
 This middleware is meant to be plugged into other district0x expressjs server modules.
 
 ## Installation
-Add `[district0x/district-server-middleware-logging "1.0.0"]` into your project.clj  
+Add <br>
+[![Clojars Project](https://img.shields.io/clojars/v/district0x/district-server-middleware-logging.svg)](https://clojars.org/district0x/district-server-middleware-logging) <br>
+into your project.clj  
 Include `[district.server.middleware.logging]` in your CLJS file
 
 ## Usage
@@ -31,5 +33,5 @@ Here's example how to use with [district-server-graphql](https://github.com/dist
     (mount/start))
 ```
 
-That's it! Not the server will log each request and request error, according to how you had set up your timbre.
+That's it! Now the server will log each request and request error, according to how you had set up your timbre.
 For easy timbre setup see [district-server-logging](https://github.com/district0x/district-server-logging). 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-server-middleware-logging "1.0.0"
+(defproject district0x/district-server-middleware-logging "1.0.1"
   :description "district0x expressjs server middleware for logging requests and request errors"
   :url "https://github.com/district0x/district-server-middleware-logging"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
This middleware logs the most relevant fields of any HTTP request coming to the server. This includes the "headers" fields.

However, this could raise security concerns, as some headers can contain sensitive and potentially risky data, such as authentication credentials or session ids.

That may imply, for example, that any user (like a sys-admin) having access to the logs of the server could potentially impersonate any user who has already logged-in.

This PR replaces the content of the "authorization" and "cookie" headers with the "&lt;hidden&gt;" text to prevent this risk.